### PR TITLE
Create lab1bmed4739

### DIFF
--- a/Lab1/Arduino/lab1bmed4739
+++ b/Lab1/Arduino/lab1bmed4739
@@ -1,0 +1,56 @@
+#include <Arduino.h>
+#include "A4988.h"
+
+#define MOTOR_STEPS 200
+#define DIR 2
+#define STEP 3
+
+char buffer[10];
+bool enter = false;
+int i = 0;
+
+A4988 stepper(MOTOR_STEPS, DIR, STEP);
+
+void setup() {
+  Serial.begin(115200); // opens serial port, sets data rate to 9600 bps
+  while (Serial.available() > 0) {
+    Serial.read(); // clears the serial buffer before starting, just in case
+  }
+  stepper.begin(30,1); // 30 is the rpm, 1 is the microstep
+}
+
+void loop() {
+  static bool waitingForInput = true;
+
+  // waits for input in general, either directly from serial or through MatLab
+  if (waitingForInput) {
+
+    double angle = 0;
+    while(!enter) {
+
+      while(Serial.available() == 0 );
+      buffer[i] = Serial.read();
+      i++;
+      if(buffer[i-1] == '\n') {
+        enter = true;
+        angle = atof(buffer);
+      }
+    } 
+
+    enter = false;
+    i = 0;
+    buffer[0] = '\0';
+
+    // this part will not be seen if using through MatLab
+    if (angle != 0) {
+      stepper.rotate(angle);
+      waitingForInput = false;
+    }
+  }
+
+  // waits for the motor to finish, in order to free itself for another input
+  if (!waitingForInput && stepper.getStepsRemaining() == 0) {
+    
+    waitingForInput = true;
+  }
+}

--- a/Lab1/MatLab/Lab1Q2Differentiator
+++ b/Lab1/MatLab/Lab1Q2Differentiator
@@ -1,0 +1,27 @@
+if ~isempty(instrfindall)
+    fclose(instrfind);
+    delete(instrfind);
+end
+clear;
+
+arduino = serial("/dev/cu.usbmodem14201","BaudRate", 115200);
+
+fopen(arduino);
+
+A = 90;
+omega = 1;
+dt = 0.2;
+t = 0;
+
+tic
+prevTheta = 0;
+while true
+    
+    theta = A*sin(omega*t);
+    fprintf(arduino, '%f\n', theta - prevTheta);
+    pause(.9);
+    t = t+dt
+    prevTheta = theta;
+end
+
+clear arduino;


### PR DESCRIPTION
Replaced Serial.parseInt() with a sequence for Serial.read(). Drastically reduced runtime. However, something internal is preventing the Arduino from obtaining Serial commands at faster rates, so it has not improved performance.